### PR TITLE
fix(import): allowing user to import 12 words mnemonic

### DIFF
--- a/soundness-cli/src/main.rs
+++ b/soundness-cli/src/main.rs
@@ -376,9 +376,14 @@ fn import_key(name: &str) -> Result<()> {
 
     // Convert mnemonic to secret key
     let secret_key_bytes = mnemonic.to_entropy();
-    let secret_key_array: [u8; 32] = secret_key_bytes.clone()
-        .try_into()
-        .map_err(|_| anyhow::anyhow!("Invalid secret key length"))?;
+    let secret_key_array = match secret_key_bytes.len() {
+        16 | 32 => {
+            let mut tmp: [u8; 32] = [0; 32];
+            tmp[..secret_key_bytes.len()].copy_from_slice(&secret_key_bytes);
+            anyhow::Ok(tmp)
+        }
+        _ => Err(anyhow::anyhow!("Invalid secret key length")),
+    }?;
 
     // Create signing key and get public key
     let signing_key = SigningKey::from_bytes(&secret_key_array);


### PR DESCRIPTION
Right now, users can only import a 24-word seed phrase. The process of converting this phrase back to its original entropy results in a 16-item array. However, creating the signing key needed to encrypt the seed phrase requires a 32-item array. To solve this, I currently adds 0s to the end of the 16-item array until it reaches the required 32 items.