### PR TITLE
Fix truncated docker command and remove orphaned content in README

### DIFF
--- a/soundness-cli/README.md
+++ b/soundness-cli/README.md
@@ -17,7 +17,7 @@ The `soundnessup` tool manages your Soundness CLI installation and makes updates
 This command downloads and runs the `soundnessup` installer.
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/soundnesslabs/soundness-layer/main/soundnessup/install | bash
+curl -sSL https://raw.githubusercontent.com/SoundnessLabs/soundness-layer/main/soundnessup/install | bash
 ```
 
 **2. Update your shell environment:**
@@ -55,7 +55,8 @@ docker compose build
 docker compose run --rm soundness-cli [command]
 
 # Example: Generate a new key pair
-docker compos
+docker compose run --rm soundness-cli generate-key --name your-key-name
+```
 
 ### Manual Installation (from Source)
 
@@ -67,8 +68,6 @@ Navigate to the `soundness-cli` directory and run:
 ```bash
 cargo install --path .
 ```
-
-curl -sSL https://raw.githubusercontent.com/soundnesslabs/soundness-layer/main/soundnessup/install | bash
 
 ## Testnet Instructions
 


### PR DESCRIPTION
- Complete truncated docker compose command example (was cut off at "docker compos")
- Add missing closing backticks for Docker installation code block
- Remove duplicate curl command that appeared without context after Manual Installation section
- Update GitHub URL capitalization from soundnesslabs to SoundnessLabs for consistency

Fixes documentation issues that would confuse new users trying to install via Docker.